### PR TITLE
feat: add autocomplete to /frog command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   "author": "JPBBerry",
   "license": "ISC",
   "dependencies": {
-    "@jadl/cmd": "^0.2.3",
-    "@jadl/embed": "^0.0.3",
+    "@jadl/cmd": "^0.7.6",
+    "@jadl/builders": "^0.1.3",
     "@jpbbots/interface": "^2.2.2",
-    "jadl": "^0.1.6",
+    "jadl": "^0.2.0",
     "topgg-autoposter": "^1.1.9",
     "undici": "^4.13.0"
   },
   "devDependencies": {
     "@types/imgur-rest-api": "^3.0.31",
     "@types/node": "^17.0.13",
-    "discord-api-types": "^0.26.0",
+    "discord-api-types": "^0.33.0",
     "typescript": "^4.5.5"
   },
   "types": "src/index.ts"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@jadl/cmd": "^0.7.6",
     "@jadl/builders": "^0.1.3",
-    "@jpbbots/interface": "^2.2.2",
-    "jadl": "^0.2.0",
+    "@jpbbots/interface": "^2.5.0",
+    "jadl": "^0.2.1",
     "topgg-autoposter": "^1.1.9",
     "undici": "^4.13.0"
   },

--- a/src/FrogBot.ts
+++ b/src/FrogBot.ts
@@ -2,7 +2,7 @@ import { SingleWorker } from 'jadl'
 import { CommandHandler } from '@jadl/cmd'
 import { Interface } from '@jpbbots/interface'
 
-import { GatewayIntentBits } from 'discord-api-types'
+import { GatewayIntentBits } from 'discord-api-types/v9'
 
 import { FrogComand } from './commands/Frog'
 import { ListCommand } from './commands/List'
@@ -16,7 +16,7 @@ export class FrogBot extends SingleWorker {
     ListCommand,
     ImgurComand
   ], {
-    interactionGuild: this.int.production ? undefined : '569907007465848842'
+    interactionGuild: this.int.production ? undefined : '356272183166763008'
   })
 
   constructor () {

--- a/src/FrogBot.ts
+++ b/src/FrogBot.ts
@@ -4,7 +4,7 @@ import { Interface } from '@jpbbots/interface'
 
 import { GatewayIntentBits } from 'discord-api-types/v9'
 
-import { FrogComand } from './commands/Frog'
+import { FrogCommand } from './commands/Frog'
 import { ListCommand } from './commands/List'
 import { ImgurComand } from './commands/Imgur'
 
@@ -12,7 +12,7 @@ export class FrogBot extends SingleWorker {
   int = new Interface()
 
   cmd = new CommandHandler(this, [
-    FrogComand,
+    FrogCommand,
     ListCommand,
     ImgurComand
   ], {

--- a/src/FrogBot.ts
+++ b/src/FrogBot.ts
@@ -16,7 +16,7 @@ export class FrogBot extends SingleWorker {
     ListCommand,
     ImgurComand
   ], {
-    interactionGuild: this.int.production ? undefined : '356272183166763008'
+    interactionGuild: this.int.production ? undefined : '569907007465848842'
   })
 
   constructor () {

--- a/src/FrogCache.ts
+++ b/src/FrogCache.ts
@@ -1,0 +1,18 @@
+import { request } from "undici";
+
+let cachedFrogs: string[] = []
+
+export default class FrogCache {
+  static async fetch () {
+    const { body } = await request('https://frogs.media/api/list')
+    cachedFrogs = await body.json()
+    return FrogCache.getCached()
+  }
+  static getCached () {
+    // Shallow copy the cached array to prevent indirect modifications to it.
+    return [...cachedFrogs]
+  }
+}
+
+// Initialize the cache
+void FrogCache.fetch()

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -1,5 +1,5 @@
 import { Command, Run, Options, Thinks } from '@jadl/cmd'
-import { Embed } from '@jadl/embed'
+import { Embed } from '@jadl/builders'
 import { request } from 'undici'
 
 @Command('frog', 'Sends a frog image')

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -1,16 +1,15 @@
 import { AutoComplete, Command, Run, Options, Thinks } from '@jadl/cmd'
 import { Embed } from '@jadl/builders'
 import { request } from 'undici'
+import FrogCache from "../FrogCache";
 
 @Command('frog', 'Sends a frog image')
 export class FrogComand {
   @Run()
   @Thinks()
   async frog(
-    @AutoComplete(async term => {
-      const { body } = await request('https://frogs.media/api/list')
-      const list: string[] = await body.json()
-      return list
+    @AutoComplete(term => {
+      return FrogCache.getCached()
         .filter(v => v.toLowerCase().includes(term.toLowerCase()))
         .slice(0, 25).map(x =>  {
           const frog = x.substring(1)

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -18,20 +18,15 @@ export class FrogComand {
     })
     @Options.String('frog', 'Specific frog to send') frog?: string
   ) {
-    if (!frog) {
-      const { body } = await request('https://frogs.media/api/random')
-      const randomFrog = await body.json()
+    // If a frog is not provided, default to random
+    const frogUrl = `https://frogs.media/api/${encodeURIComponent(frog ?? 'random')}`
+    const { body } = await request(frogUrl)
+    const frogDetails = await body.json()
 
-      return new Embed()
-        .color(0x63e084)
-        .title(`${randomFrog.name[0].toUpperCase() + randomFrog.name.substr(1)} frog`, `https://frogs.media/${randomFrog.name}`)
-        .image(randomFrog.url)
-        .footer(`To see this frog again use "/frog ${randomFrog.name}"`)
-    } else {
-      return new Embed()
-        .color(0x63e084)
-        .title(`${frog} frog`)
-        .image(`https://frogs.media/api/images/${encodeURIComponent(frog)}.gif`)
-    }
+    return new Embed()
+      .color(0x63e084)
+      .title(`${frogDetails.name[0].toUpperCase() + frogDetails.name.substr(1)} frog`, `https://frogs.media/${frogDetails.name}`)
+      .image(frogDetails.url)
+      .footer(`To see this frog again use "/frog ${frogDetails.name}"`)
   }
 }

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -4,7 +4,7 @@ import { request } from 'undici'
 import FrogCache from "../FrogCache";
 
 @Command('frog', 'Sends a frog image')
-export class FrogComand {
+export class FrogCommand {
   @Run()
   @Thinks()
   async frog(

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -1,4 +1,4 @@
-import { Command, Run, Options, Thinks } from '@jadl/cmd'
+import { AutoComplete, Command, Run, Options, Thinks } from '@jadl/cmd'
 import { Embed } from '@jadl/builders'
 import { request } from 'undici'
 
@@ -7,6 +7,16 @@ export class FrogComand {
   @Run()
   @Thinks()
   async frog(
+    @AutoComplete(async term => {
+      const { body } = await request('https://frogs.media/api/list')
+      const list: string[] = await body.json()
+      return list
+        .filter(v => v.toLowerCase().includes(term.toLowerCase()))
+        .slice(0, 25).map(x =>  {
+          const frog = x.substring(1)
+          return { name: frog, value: frog }
+        })
+    })
     @Options.String('frog', 'Specific frog to send') frog?: string
   ) {
     if (!frog) {

--- a/src/commands/Frog.ts
+++ b/src/commands/Frog.ts
@@ -18,8 +18,9 @@ export class FrogCommand {
     })
     @Options.String('frog', 'Specific frog to send') frog?: string
   ) {
-    // If a frog is not provided, default to random
-    const frogUrl = `https://frogs.media/api/${encodeURIComponent(frog ?? 'random')}`
+    // If a frog is not provided or its name isn't cached, default to a random frog
+    const frogName = frog && FrogCache.getCached().includes('/' + frog) ? frog : 'random'
+    const frogUrl = `https://frogs.media/api/${encodeURIComponent(frogName)}`
     const { body } = await request(frogUrl)
     const frogDetails = await body.json()
 

--- a/src/commands/Imgur.ts
+++ b/src/commands/Imgur.ts
@@ -1,5 +1,5 @@
 import { Command, Run, Thinks, CommandError } from '@jadl/cmd'
-import { Embed } from '@jadl/embed'
+import { Embed } from '@jadl/builders'
 import { request } from 'undici'
 
 @Command('imgur', 'Requests a random frog from imgur')

--- a/src/commands/List.ts
+++ b/src/commands/List.ts
@@ -1,14 +1,13 @@
 import { Command, Run, Thinks } from '@jadl/cmd'
 import { Embed } from '@jadl/builders'
-import { request } from 'undici'
+import FrogCache from "../FrogCache";
 
 @Command('list', 'Lists all the frog names')
 export class ListCommand {
   @Run()
   @Thinks()
   async list () {
-    const { body } = await request('https://frogs.media/api/list')
-    const list = await body.json()
+    const list = await FrogCache.fetch()
 
     return new Embed()
       .title('List of frogs', 'https://frogs.media')

--- a/src/commands/List.ts
+++ b/src/commands/List.ts
@@ -1,5 +1,5 @@
 import { Command, Run, Thinks } from '@jadl/cmd'
-import { Embed } from '@jadl/embed'
+import { Embed } from '@jadl/builders'
 import { request } from 'undici'
 
 @Command('list', 'Lists all the frog names')
@@ -9,7 +9,7 @@ export class ListCommand {
   async list () {
     const { body } = await request('https://frogs.media/api/list')
     const list = await body.json()
-    
+
     return new Embed()
       .title('List of frogs', 'https://frogs.media')
       .description(list.map(x => `\`${x.substr(1)}\``).join(', ') + ` (${list.length} total)`)


### PR DESCRIPTION
This pull request adds autocomplete to the `/frog` command. In order to facilitate this, dependencies had to be updated and `@jadl/embed` moved to `@jadl/builders`. Additionally, the embeds for frog images (random vs requested) have been made consistent. 

To allow the bot to respond to autocomplete interactions in a timely manner, a basic caching implementation has been implemented within `src/frogCache.ts`. This cache is initialized when the bot is started and updated every time the `/list` command is run.